### PR TITLE
Add script clone repo

### DIFF
--- a/scripts/clone-repositories-list/README.md
+++ b/scripts/clone-repositories-list/README.md
@@ -21,7 +21,7 @@ _Examples:_
 
 - Export the required environment variables:
     - `ORG_NAME` = Organization name eg:. `export ORG_NAME=DNXLabs`
-    - `VCS_URL` = Version control system eg:. `export VCS=github.com`
+    - `VCS_URL` = Version control system eg:. `export VCS_URL=github.com`
 - From the command line run: `bash clone-repositories.sh "repo-1@1.0.1" repo-2@1.2.1" "repo-3@2.0.3"`
 
 ## Versioning

--- a/scripts/clone-repositories-list/README.md
+++ b/scripts/clone-repositories-list/README.md
@@ -20,8 +20,8 @@ _Examples:_
 ## How to run
 
 - Export the required environment variables:
-    - `ORG_NAME` = Organization name eg:. `export ORG_NAME=DNXLabs`
-    - `VCS_URL` = Version control system eg:. `export VCS_URL=github.com`
+    - `ORG_NAME` = Organization name, this variable is used to compose the repository URL e.g.: `export ORG_NAME=DNXLabs`
+    - `VCS_URL` = Version control system, this variable is used to compose the repository URL e.g.: `export VCS_URL=github.com`
 - From the command line run: `bash clone-repositories.sh "repo-1@1.0.1" repo-2@1.2.1" "repo-3@2.0.3"`
 
 ## Versioning

--- a/scripts/clone-repositories-list/README.md
+++ b/scripts/clone-repositories-list/README.md
@@ -1,0 +1,38 @@
+# clone-repositories
+
+This script clones a list of GIT repositories.
+
+## Use case:
+
+Used extensively to clone private repositories locally using local or CICD pipeline credentials, eliminating the need to export or store GIT credentials.
+
+_Examples:_
+
+- Terraform modules stored in private repositories
+- Applications that uses private repositories as dependencies.
+
+## Prerequisites
+
+- Bash
+- GIT
+
+
+## How to run
+
+- Export the required environment variables:
+    - `ORG_NAME` = Organization name eg:. `export ORG_NAME=DNXLabs`
+    - `VCS_URL` = Version control system eg:. `export VCS=github.com`
+- From the command line run: `bash clone-repositories.sh "repo-1@1.0.1" repo-2@1.2.1" "repo-3@2.0.3"`
+
+## Versioning
+
+1.0.0
+
+
+## Author
+
+* **Woltter Xavier** - *Initial work* - [wvxavier](https://github.com/wvxavier)
+
+## License
+
+Apache 2 Licensed. See [LICENSE](https://github.com/DNXLabs/tools-box/blob/master/LICENSE) for full details.

--- a/scripts/clone-repositories-list/clone-repositories.sh
+++ b/scripts/clone-repositories-list/clone-repositories.sh
@@ -1,0 +1,32 @@
+#/bin/bash
+
+#Checking if necessary environment variables are set
+if [[ -z "${ORG_NAME}" ]] ; then
+  echo "ORG_NAME environment variable is not set"
+  exit
+fi
+
+if [[ -z "${VCS_URL}" ]] ; then
+  echo "VCS_URL environment variable is not set"
+  exit
+fi
+
+#List of private repositories and tags from arguments
+declare -a repos=("$@")
+
+# Disabe GIT advice
+git config --global advice.detachedHead false
+
+for PACKAGE in "${repos[@]}"; do
+    repoName="$(cut -d'@' -f1 <<< $PACKAGE)"
+    repoVersion="$(cut -d'@' -f2 <<< $PACKAGE)"
+    if [ -d "./local-repositories/$repoName" ] 
+        then
+            echo "Repository $repoName already exists locally." 
+        else
+            echo "Cloning git@$VCS_URL:$ORG_NAME/$repoName.git..."
+            git clone -b $repoVersion git@$VCS_URL:$ORG_NAME/$repoName.git ./private-repositories/$repoName
+    fi
+done   
+
+ 

--- a/scripts/clone-repositories-list/clone-repositories.sh
+++ b/scripts/clone-repositories-list/clone-repositories.sh
@@ -2,12 +2,12 @@
 
 #Checking if necessary environment variables are set
 if [[ -z "${ORG_NAME}" ]] ; then
-  echo "ORG_NAME environment variable is not set"
+  echo "ORG_NAME environment variable is not set, this variable is used to compose the repository URL"
   exit
 fi
 
 if [[ -z "${VCS_URL}" ]] ; then
-  echo "VCS_URL environment variable is not set"
+  echo "VCS_URL environment variable is not set, this variable is used to compose the repository URL"
   exit
 fi
 

--- a/scripts/clone-repositories-list/clone-repositories.sh
+++ b/scripts/clone-repositories-list/clone-repositories.sh
@@ -25,7 +25,7 @@ for PACKAGE in "${repos[@]}"; do
             echo "Repository $repoName already exists locally." 
         else
             echo "Cloning git@$VCS_URL:$ORG_NAME/$repoName.git..."
-            git clone -b $repoVersion git@$VCS_URL:$ORG_NAME/$repoName.git ./private-repositories/$repoName
+            git clone -b $repoVersion git@$VCS_URL:$ORG_NAME/$repoName.git ./local-repositories/$repoName
     fi
 done   
 


### PR DESCRIPTION
This script is used extensively to clone private repositories locally using local or CICD pipeline credentials, eliminating the need to export or store keys.

This is how you can test it: 

```
$ export ORG_NAME=DNXLabs VCS_URL=github.com
$ curl -s https://raw.githubusercontent.com/DNXLabs/tools-box/add-script-clone-repo/scripts/clone-repositories-list/clone-repositories.sh | bash -s -- "terraform-aws-elasticache@0.4.0" "terraform-aws-waf@1.0.0"
```